### PR TITLE
Ityp split

### DIFF
--- a/mpi_submit_script.sh
+++ b/mpi_submit_script.sh
@@ -72,7 +72,7 @@ echo "Lpoint = " $L
 echo "spoint = " $s
 echo "qpoint = " $qp
 
-PMLL=10
+PMLL=50
 
 #
 # The MPI program to execute:
@@ -95,9 +95,9 @@ cat > test_input.${SGE_TASK_ID} << EOF
   &filenames
 	domain_file = '${DOMAIN}',
 	mass_file = '${MASS}', 
-	flfrc1 = '/home/1628/QuantumEspresso/GaAs/results/GaAs444.fc', 
-	flfrc2 = '/home/1628/QuantumEspresso/GaAs/results/GaAs444.fc'
-	mass_input = .true.
+	flfrc1 = '/home/1628/QuantumEspresso/Si/results/Si_q2.fc', 
+	flfrc2 = '/home/1628/QuantumEspresso/Si/results/Si_q2.fc'
+	mass_input = .false.
 /
   &system
 	simulation_type = 'interface'
@@ -106,11 +106,11 @@ cat > test_input.${SGE_TASK_ID} << EOF
 	periodic = .true.
 	crystal_coordinates = .false.
 	asr = 'simple'
-	wavetype = 'full'
+	wavetype = 'half'
 	q(1) = 0.0, 0.0, 0.1
 	mode = 3
-	sigmamax = 3
-	expense_estimate = .true.
+	sigmamax = 2
+	expense_estimate = .false.
 /
   &qlists
 	q_from_file = .false.

--- a/mpi_submit_script.sh
+++ b/mpi_submit_script.sh
@@ -29,7 +29,7 @@
 #----------------------------------
 #                Farber parameters
 # tells cluster to assign (20) processors
-#$ -pe mpi 36
+#$ -pe mpi 5
 # tells cluster to allocate 1GB memory PER processor
 # $ -l m_mem_free=3G
 # tells cluster to give you exclusive access to node
@@ -46,7 +46,7 @@
 #      Load any packages you need to run it
 vpkg_require openmpi/intel64
 vpkg_require gnuplot/4.6
-OPENMPI_FLAGS='-np 36'
+OPENMPI_FLAGS='-np 5'
 
 L=`expr $SGE_TASK_ID % 11`
 s=`expr $SGE_TASK_ID / 11`
@@ -97,13 +97,13 @@ cat > test_input.${SGE_TASK_ID} << EOF
 	mass_file = '${MASS}', 
 	flfrc1 = '/home/1628/QuantumEspresso/GaAs/results/GaAs444.fc', 
 	flfrc2 = '/home/1628/QuantumEspresso/GaAs/results/GaAs444.fc'
-	mass_input = .false.
+	mass_input = .true.
 /
   &system
 	simulation_type = 'interface'
-	PD(1) = 11, 11, 20
+	PD(1) = 11, 11, 22
 	LPML = ${PMLL}
-	periodic = .false.
+	periodic = .true.
 	crystal_coordinates = .false.
 	asr = 'simple'
 	wavetype = 'full'
@@ -146,7 +146,7 @@ cat > test_input.${SGE_TASK_ID} << EOF
 /
 EOF
 
-
+echo $MY_EXE
 
 mpirun -quiet ${OPENMPI_FLAGS} $MY_EXE < test_input.${SGE_TASK_ID} > output_test.o${SGE_TASK_ID}
 

--- a/src/FDPML.f90
+++ b/src/FDPML.f90
@@ -470,7 +470,7 @@ PROGRAM FDPML
 !	Loading the primary domain
 
 	call gen_TD(domain_file, mass_file, amass_TD, ityp_TD, PD, TD, periodic, ntyp, &
-						amass1, amass2, natc, itypc, mass_input, LPML)
+						amass1, amass2, natc, itypc, mass_input, LPML, nr3)
 						
 !**	
 	CALL cpu_time(finish)

--- a/src/mp_module.f90
+++ b/src/mp_module.f90
@@ -107,7 +107,7 @@ CONTAINS
 	END SUBROUTINE
 
 	SUBROUTINE calculate_displs(counts, displs)
-		INTEGER(KIND = RP), DIMENSION(world_size) :: counts, displs
+		INTEGER(KIND = IP), DIMENSION(world_size) :: counts, displs
 		INTEGER :: i
 		displs(1)=0
 		DO i=2,world_size

--- a/src/mp_module.f90
+++ b/src/mp_module.f90
@@ -134,7 +134,7 @@ CONTAINS
 	END SUBROUTINE
 	
 	SUBROUTINE get_nrows(natoms, my_natoms, rem, my_nrows, nrows, everyones_atoms, &
-						atoms_start, everyones_rows, TD, natc, ityp_TD)
+						atoms_start, everyones_rows, TD, natc)
 						
 !	Calculate the number of atoms(rows) assigned to every processor
 !	Nomenclature :
@@ -157,10 +157,10 @@ CONTAINS
 												everyones_rows(world_size)
 		INTEGER								::	natc, i
 		REAL								::	TD(3)
-		INTEGER								::	ityp_TD(int(TD(1)),int(TD(2)),int(TD(3)),natc)
 		
 		
-		natoms = size(ityp_TD)
+		natoms = int(TD(1))*int(TD(2))*int(TD(3))*natc
+		print *, 'Hello'
 		nrows = 3*natoms
 		if (io_node) WRITE (stdout, '(a, I11)')' Total number of atoms inside simulation cell =',&
 										natoms


### PR DESCRIPTION
Updated the code to scale simulations across the cluster:

Major changes include:
1 - Splitting up of itypTD, amassTD, itypPD and amassPD domains across all nodes in the cluster. Thus these variables are no longer a memory bottleneck for the code. 
2 - Loading primary domain as a sequence of files, the total number of files the primary domain is split into = total number of processors used for the simulation.
3 - There is slight communication overhead induced because of these changes - the local primary domains need to be communicated to their respective local total domains. However, I do believe the code is still compute bound and not communication bound. Hence, this shouldn't be a major issue.
4 - Individual processor domains are now printed separately to stdout to avoid communication overhear.

Things that need to be done:
1 - Major thing that needs to be done is code clean up. There is a lot of legacy code i.e. code that was developed when I was an amateur developer. While this doesn't cause any performance issues, I believe modifying it would increase the readability significantly. The most important of these issues include removing variables in the FDPML.f90 which have since moved their own modules and are out of the scope of FDPML.f90.  
2 - Need to update total domain generation routine to include non-periodic domains. This should be a small change and I'll get it done ASAP. 
3 - remove MPI-IO entirely and use Fortran's default IO. I'll get it done ASAP.
4 - Suggestion - create an input MPI communicator to avoid the limitations of point # 2 (Major changes include) above. In such a scenario the number of files the primary domain is split into = total number of processors used in input MPI communicator. 